### PR TITLE
Add GitHub Pages deploy workflow

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -3,7 +3,7 @@ name: Deploy to GitHub Pages
 on:
   # Deploy whenever the default branch updates...
   push:
-    branches: [master, typescript-port]
+    branches: [master]
   # ...and allow manual runs (e.g. to test from a feature branch).
   workflow_dispatch:
 

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,46 @@
+name: Deploy to GitHub Pages
+
+on:
+  # Deploy whenever the default branch updates...
+  push:
+    branches: [master]
+  # ...and allow manual runs (e.g. to test from a feature branch).
+  workflow_dispatch:
+
+# Allow the job to push the built site to the gh-pages branch.
+permissions:
+  contents: write
+
+concurrency:
+  group: pages-deploy
+  cancel-in-progress: true
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Publish dist/ to gh-pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist
+          # Writes a .nojekyll file so Pages serves all built assets as-is.
+          enable_jekyll: false

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -3,7 +3,7 @@ name: Deploy to GitHub Pages
 on:
   # Deploy whenever the default branch updates...
   push:
-    branches: [master]
+    branches: [master, typescript-port]
   # ...and allow manual runs (e.g. to test from a feature branch).
   workflow_dispatch:
 
@@ -20,13 +20,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -3,7 +3,7 @@ name: Deploy to GitHub Pages
 on:
   # Deploy whenever the default branch updates...
   push:
-    branches: [master]
+    branches: [master, typescript-port]
   # ...and allow manual runs (e.g. to test from a feature branch).
   workflow_dispatch:
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "description": "Blue Noise Stippling generator",
+  "packageManager": "pnpm@10.33.2",
   "scripts": {
     "dev": "node dev.mjs",
     "build": "node build.mjs",
@@ -25,5 +26,8 @@
     "typescript": "^5.9.0",
     "typescript-eslint": "^8.60.0",
     "vitest": "^4.1.7"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": ["esbuild"]
   }
 }


### PR DESCRIPTION
Follow-up to #2 (which is already merged). Adds the GitHub Actions workflow that builds with esbuild and publishes `dist/` to the `gh-pages` branch on pushes to `master` (plus manual `workflow_dispatch`).

- `.github/workflows/deploy-pages.yml` — checkout → pnpm install → `pnpm build` → publish `dist/` via `peaceiris/actions-gh-pages`
- `package.json` — pin `packageManager` and allow esbuild's install script so CI `pnpm install --frozen-lockfile` + `pnpm build` work
- Actions pinned to their Node 24 majors (checkout@v6, setup-node@v6, pnpm/action-setup@v6)

Verified end-to-end: the workflow ran green and published the live site at https://joeedh.github.io/BlueNoiseStippling/

🤖 Generated with [Claude Code](https://claude.com/claude-code)